### PR TITLE
Update exe_dsspcmbi.dat

### DIFF
--- a/Biskit/data/defaults/exe_dsspcmbi.dat
+++ b/Biskit/data/defaults/exe_dsspcmbi.dat
@@ -3,7 +3,7 @@
 comment=dsspcmbi http://swift.cmbi.ru.nl/gv/dssp/
 
 ## binary
-bin=dsspcmbi
+bin=mkdssp
 
 ## working directory
 cwd=


### PR DESCRIPTION
current versions of DSSP have executables named ```mkdssp```. Thus, this change.